### PR TITLE
Fix `ft transfer call` message check

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -174,7 +174,6 @@ category = "Test"
 command = "${CARGO}"
 args = [
     "test",
-    "test_ft_transfer_call_user_message",
     "--features",
     "${CARGO_FEATURES_TEST}",
     "--",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -174,6 +174,7 @@ category = "Test"
 command = "${CARGO}"
 args = [
     "test",
+    "test_ft_transfer_call_user_message",
     "--features",
     "${CARGO_FEATURES_TEST}",
     "--",

--- a/eth-connector-tests/src/connector.rs
+++ b/eth-connector-tests/src/connector.rs
@@ -345,10 +345,7 @@ async fn test_ft_transfer_call_user_message() {
     //println!("{:#?}", res);
     assert!(res.is_success());
 
-    let balance = contract
-        .get_eth_on_near_balance(&receiver_id)
-        .await
-        .unwrap();
+    let balance = contract.get_eth_on_near_balance(receiver_id).await.unwrap();
     assert_eq!(balance.0, DEPOSITED_FEE + transfer_amount.0);
     let balance = contract
         .get_eth_on_near_balance(user_acc.id())
@@ -377,7 +374,7 @@ async fn test_ft_transfer_call_user_message() {
         .unwrap()
         .json::<Vec<AccountId>>()
         .unwrap();
-    assert!(res.contains(&receiver_id));
+    assert!(res.contains(receiver_id));
 
     let res = user_acc
         .call(contract.contract.id(), "ft_transfer_call")
@@ -389,10 +386,7 @@ async fn test_ft_transfer_call_user_message() {
         .unwrap();
     assert!(res.is_failure());
     assert!(contract.check_error_message(res, "ERR_INVALID_ON_TRANSFER_MESSAGE_FORMAT"));
-    let balance = contract
-        .get_eth_on_near_balance(&receiver_id)
-        .await
-        .unwrap();
+    let balance = contract.get_eth_on_near_balance(receiver_id).await.unwrap();
     assert_eq!(balance.0, DEPOSITED_FEE + transfer_amount.0);
     let balance = contract
         .get_eth_on_near_balance(user_acc.id())

--- a/eth-connector-tests/src/connector.rs
+++ b/eth-connector-tests/src/connector.rs
@@ -194,6 +194,11 @@ async fn test_deposit_eth_to_near_balance_total_supply() -> anyhow::Result<()> {
 #[tokio::test]
 async fn test_deposit_eth_to_aurora_balance_total_supply() -> anyhow::Result<()> {
     let contract = TestContract::new().await?;
+    contract
+        .set_engine_account(&contract.contract.id())
+        .await
+        .unwrap();
+
     contract.call_deposit_eth_to_aurora().await?;
     assert!(
         contract.call_is_used_proof(PROOF_DATA_ETH).await?,
@@ -266,7 +271,11 @@ async fn test_ft_transfer_call_without_message() -> anyhow::Result<()> {
     let transfer_amount: U128 = 50.into();
     let memo: Option<String> = None;
     let message = "";
-    // Send to Aurora contract with wrong message should failed
+    contract
+        .set_engine_account(contract.contract.id())
+        .await
+        .unwrap();
+    // Send to Engine contract with wrong message should failed
     let res = contract
         .contract
         .call("ft_transfer_call")
@@ -333,7 +342,7 @@ async fn test_ft_transfer_call_user_message() {
     let transfer_amount: U128 = 50.into();
     let memo: Option<String> = None;
     let message = "";
-    // Send to Aurora contract with wrong message should failed
+    // Send to non-engine contract with wrong message should failed
     let res = user_acc
         .call(contract.contract.id(), "ft_transfer_call")
         .args_json((&receiver_id, transfer_amount, &memo, message))
@@ -342,7 +351,6 @@ async fn test_ft_transfer_call_user_message() {
         .transact()
         .await
         .unwrap();
-    //println!("{:#?}", res);
     assert!(res.is_success());
 
     let balance = contract.get_eth_on_near_balance(receiver_id).await.unwrap();
@@ -356,15 +364,12 @@ async fn test_ft_transfer_call_user_message() {
         DEPOSITED_AMOUNT - DEPOSITED_FEE - transfer_amount.0
     );
 
-    let res = contract
-        .contract
-        .call("set_engine_account")
-        .args_json((&receiver_id,))
-        .gas(DEFAULT_GAS)
-        .transact()
+    contract
+        .set_and_check_access_right(contract.contract.id())
         .await
         .unwrap();
-    assert!(res.is_success());
+
+    contract.set_engine_account(&receiver_id).await.unwrap();
 
     let res = contract
         .contract
@@ -376,6 +381,7 @@ async fn test_ft_transfer_call_user_message() {
         .unwrap();
     assert!(res.contains(receiver_id));
 
+    // Send to engine contract with wrong message should failed
     let res = user_acc
         .call(contract.contract.id(), "ft_transfer_call")
         .args_json((&receiver_id, transfer_amount, &memo, message))
@@ -396,6 +402,47 @@ async fn test_ft_transfer_call_user_message() {
         balance.0,
         DEPOSITED_AMOUNT - DEPOSITED_FEE - transfer_amount.0
     );
+}
+
+#[tokio::test]
+async fn test_set_and_get_engine_account() {
+    let contract = TestContract::new().await.unwrap();
+    contract.call_deposit_eth_to_near().await.unwrap();
+
+    let user_acc = contract.create_sub_account("eth_recipient").await.unwrap();
+    let res = user_acc
+        .call(contract.contract.id(), "set_engine_account")
+        .args_json((&contract.contract.id(),))
+        .gas(DEFAULT_GAS)
+        .transact()
+        .await
+        .unwrap();
+    assert!(res.is_failure());
+    assert!(contract.check_error_message(res, "ERR_ACCESS_RIGHT"));
+
+    contract
+        .set_and_check_access_right(user_acc.id())
+        .await
+        .unwrap();
+
+    let res = user_acc
+        .call(contract.contract.id(), "set_engine_account")
+        .args_json((&contract.contract.id(),))
+        .gas(DEFAULT_GAS)
+        .transact()
+        .await
+        .unwrap();
+    assert!(res.is_success());
+
+    let res = contract
+        .contract
+        .call("get_engine_accounts")
+        .view()
+        .await
+        .unwrap()
+        .json::<Vec<AccountId>>()
+        .unwrap();
+    assert!(res.contains(contract.contract.id()));
 }
 
 #[tokio::test]
@@ -564,6 +611,9 @@ async fn test_ft_transfer_call_fee_greater_than_amount() -> anyhow::Result<()> {
     let relayer_id = "relayer.root";
     let message = [relayer_id, hex::encode(msg).as_str()].join(":");
     let memo: Option<String> = None;
+
+    // For `ft_transfer_call` we don't check correcness for `fee amount`.
+    // So transactions should be success, and balances shouldn't changes
     let res = contract
         .contract
         .call("ft_transfer_call")
@@ -572,12 +622,10 @@ async fn test_ft_transfer_call_fee_greater_than_amount() -> anyhow::Result<()> {
         .deposit(ONE_YOCTO)
         .transact()
         .await?;
-    assert!(res.is_failure());
-    assert!(contract.check_error_message(res, "insufficient balance for fee"));
+    assert!(res.is_success());
 
     let receiver_id = AccountId::try_from(DEPOSITED_RECIPIENT.to_string()).unwrap();
     let balance = contract.get_eth_on_near_balance(&receiver_id).await?;
-    assert_eq!(balance.0, DEPOSITED_AMOUNT - DEPOSITED_FEE);
     assert_eq!(balance.0, DEPOSITED_AMOUNT - DEPOSITED_FEE);
 
     let balance = contract
@@ -656,6 +704,10 @@ async fn test_admin_controlled_admin_can_perform_actions_when_paused() -> anyhow
     // 2nd deposit call when paused, but the admin is calling it - should succeed
     // NB: We can use `PROOF_DATA_ETH` this will be just a different proof but the same deposit
     // method which should be paused
+    contract
+        .set_engine_account(&contract.contract.id())
+        .await
+        .unwrap();
     contract.call_deposit_eth_to_aurora().await?;
 
     // Pause withdraw

--- a/eth-connector-tests/src/connector.rs
+++ b/eth-connector-tests/src/connector.rs
@@ -195,7 +195,7 @@ async fn test_deposit_eth_to_near_balance_total_supply() -> anyhow::Result<()> {
 async fn test_deposit_eth_to_aurora_balance_total_supply() -> anyhow::Result<()> {
     let contract = TestContract::new().await?;
     contract
-        .set_engine_account(&contract.contract.id())
+        .set_engine_account(contract.contract.id())
         .await
         .unwrap();
 
@@ -369,7 +369,7 @@ async fn test_ft_transfer_call_user_message() {
         .await
         .unwrap();
 
-    contract.set_engine_account(&receiver_id).await.unwrap();
+    contract.set_engine_account(receiver_id).await.unwrap();
 
     let res = contract
         .contract
@@ -705,7 +705,7 @@ async fn test_admin_controlled_admin_can_perform_actions_when_paused() -> anyhow
     // NB: We can use `PROOF_DATA_ETH` this will be just a different proof but the same deposit
     // method which should be paused
     contract
-        .set_engine_account(&contract.contract.id())
+        .set_engine_account(contract.contract.id())
         .await
         .unwrap();
     contract.call_deposit_eth_to_aurora().await?;

--- a/eth-connector-tests/src/utils.rs
+++ b/eth-connector-tests/src/utils.rs
@@ -306,6 +306,19 @@ impl TestContract {
         }
         Ok(())
     }
+
+    pub async fn set_engine_account(&self, acc: &AccountId) -> anyhow::Result<()> {
+        let res = self
+            .contract
+            .call("set_engine_account")
+            .args_json((&acc,))
+            .gas(DEFAULT_GAS)
+            .transact()
+            .await
+            .unwrap();
+        assert!(res.is_success());
+        Ok(())
+    }
 }
 
 pub fn print_logs(res: ExecutionFinalResult) {

--- a/eth-connector/src/connector.rs
+++ b/eth-connector/src/connector.rs
@@ -86,8 +86,8 @@ pub trait EngineStorageManagement {
     fn engine_storage_unregister(&mut self, sender_id: AccountId, force: Option<bool>) -> bool;
 }
 
-#[ext_contract(ext_known_enine_accounts)]
-pub trait KnownEnginAccountsManagement {
+#[ext_contract(ext_known_engine_accounts)]
+pub trait KnownEngineAccountsManagement {
     fn set_engine_account(&mut self, engine_account: AccountId);
 
     fn get_engine_accounts(&self) -> Vec<AccountId>;

--- a/eth-connector/src/connector.rs
+++ b/eth-connector/src/connector.rs
@@ -90,5 +90,7 @@ pub trait EngineStorageManagement {
 pub trait KnownEngineAccountsManagement {
     fn set_engine_account(&mut self, engine_account: AccountId);
 
+    fn remove_engine_account(&mut self, engine_account: AccountId);
+
     fn get_engine_accounts(&self) -> Vec<AccountId>;
 }

--- a/eth-connector/src/connector.rs
+++ b/eth-connector/src/connector.rs
@@ -85,3 +85,10 @@ pub trait EngineStorageManagement {
 
     fn engine_storage_unregister(&mut self, sender_id: AccountId, force: Option<bool>) -> bool;
 }
+
+#[ext_contract(ext_known_enine_accounts)]
+pub trait KnownEnginAccountsManagement {
+    fn set_engine_account(&mut self, engine_account: AccountId);
+
+    fn get_engine_accounts(&self) -> Vec<AccountId>;
+}

--- a/eth-connector/src/lib.rs
+++ b/eth-connector/src/lib.rs
@@ -274,6 +274,12 @@ impl KnownEngineAccountsManagement for EthConnectorContract {
         self.known_engine_accounts.push(engine_account);
     }
 
+    fn remove_engine_account(&mut self, engine_account: AccountId) {
+        self.assert_access_right().sdk_unwrap();
+        self.known_engine_accounts
+            .retain(|acc| *acc != engine_account);
+    }
+
     fn get_engine_accounts(&self) -> Vec<AccountId> {
         self.known_engine_accounts.clone()
     }


### PR DESCRIPTION
## Description
It fixes bugs related to `ft_transfer_call` `sender_id` check for validation messages.

Currently, when checking `sender_id == receiver_id`, we do not validate is it Aurora contract or not.

## Solution

Introduce functions:
* `set_engine_contract`
* `get_engine_contracts`

in `ft_transfer_call` change message verification condition to:

```
if known_engine_contracts.contains(receveir_id) { .... }
```

## Tests

Extended tests for `ft_transfer_call` message verification.

## Breaking changes
No.

## Gas cost
Not changed.