### PR TITLE
Fix (audit AUR-11): Infinite Amounts Can Be Transferred to One’s Self

### DIFF
--- a/eth-connector-tests/src/connector.rs
+++ b/eth-connector-tests/src/connector.rs
@@ -1726,3 +1726,77 @@ async fn test_manage_engine_accounts() {
     assert!(!res.contains(&acc1));
     assert!(res.contains(&acc2));
 }
+
+#[tokio::test]
+async fn test_ft_transfer_call_insufficient_sender_balance() -> anyhow::Result<()> {
+    let contract = TestContract::new().await?;
+    contract.call_deposit_eth_to_near().await?;
+
+    let recipient_id = AccountId::try_from(DEPOSITED_RECIPIENT.to_string()).unwrap();
+    let balance = contract.get_eth_on_near_balance(&recipient_id).await?;
+    assert_eq!(balance.0, DEPOSITED_AMOUNT - DEPOSITED_FEE);
+
+    let balance = contract
+        .get_eth_on_near_balance(contract.contract.id())
+        .await?;
+    assert_eq!(balance.0, DEPOSITED_FEE);
+
+    let fee: u128 = 0;
+    let mut msg = U256::from(fee).as_byte_slice().to_vec();
+    msg.append(
+        &mut validate_eth_address(RECIPIENT_ETH_ADDRESS)
+            .as_bytes()
+            .to_vec(),
+    );
+    let message = [CONTRACT_ACC, hex::encode(msg).as_str()].join(":");
+    let memo: Option<String> = None;
+
+    let transfer_amount: U128 = (DEPOSITED_FEE + 1).into();
+    let res = contract
+        .contract
+        .call("ft_transfer_call")
+        .args_json((&contract.contract.id(), transfer_amount, &memo, &message))
+        .gas(DEFAULT_GAS)
+        .deposit(ONE_YOCTO)
+        .transact()
+        .await?;
+    assert!(res.is_failure());
+    assert!(contract.check_error_message(res, "Insufficient sender balance"));
+    let balance = contract
+        .get_eth_on_near_balance(contract.contract.id())
+        .await?;
+    assert_eq!(balance.0, DEPOSITED_FEE);
+
+    let transfer_amount: U128 = 0.into();
+    let res = contract
+        .contract
+        .call("ft_transfer_call")
+        .args_json((&contract.contract.id(), transfer_amount, &memo, &message))
+        .gas(DEFAULT_GAS)
+        .deposit(ONE_YOCTO)
+        .transact()
+        .await?;
+    assert!(res.is_failure());
+    assert!(contract.check_error_message(res, "The amount should be a positive non zero number"));
+    let balance = contract
+        .get_eth_on_near_balance(contract.contract.id())
+        .await?;
+    assert_eq!(balance.0, DEPOSITED_FEE);
+
+    let transfer_amount: U128 = DEPOSITED_FEE.into();
+    let res = contract
+        .contract
+        .call("ft_transfer_call")
+        .args_json((&contract.contract.id(), transfer_amount, &memo, &message))
+        .gas(DEFAULT_GAS)
+        .deposit(ONE_YOCTO)
+        .transact()
+        .await?;
+    assert!(res.is_success());
+    let balance = contract
+        .get_eth_on_near_balance(contract.contract.id())
+        .await?;
+    assert_eq!(balance.0, DEPOSITED_FEE);
+
+    Ok(())
+}

--- a/eth-connector-tests/src/connector.rs
+++ b/eth-connector-tests/src/connector.rs
@@ -1455,17 +1455,17 @@ async fn test_engine_ft_transfer_call() {
     assert!(res.is_success());
 
     assert_eq!(
-        DEPOSITED_AMOUNT - DEPOSITED_FEE - transfer_amount.0,
+        DEPOSITED_FEE + transfer_amount.0,
         contract
-            .get_eth_on_near_balance(user_acc.id())
+            .get_eth_on_near_balance(contract.contract.id())
             .await
             .unwrap()
             .0
     );
     assert_eq!(
-        DEPOSITED_FEE + transfer_amount.0,
+        DEPOSITED_AMOUNT - DEPOSITED_FEE - transfer_amount.0,
         contract
-            .get_eth_on_near_balance(contract.contract.id())
+            .get_eth_on_near_balance(user_acc.id())
             .await
             .unwrap()
             .0


### PR DESCRIPTION
## Description

After Sigma Prime Aurora Engine and Eth-Connector audit, was detected potential issue: **AUR-11 - Infinite Amounts Can Be Transferred to One’s**.

### Details

Balance checks are performed in the function `internal_transfer_eth_on_near()`. The following snippet of the function `ft_transfer_call()` show how the balance checks are skipped if `sender_id == receiver_id`.

```
if sender_id != receiver_id {
    self.internal_transfer_eth_on_near(&sender_id, &receiver_id, amount, memo)?;
}
```

The impact is not significant to the current contract as the net balances and total supply remain unchanged. However, this poses a potential threat to third party contracts. `ft_transfer_call()` makes the external call `receiver_id.ft_on_transfer(amount, msg, sender_id)`. Since we are able to set amount as any arbitrary value this 
may lead to issues in the accounting of third party contracts.

## Solution

Added extra verification in `ft_transfer_call`, for the case `sender_id == receiver_id`:
- `amount > 0`
- `balance_of_sender >= amount`

## Gas cost

Not changed

## How to review

Pay attention to `ft_transfer_call` method

## Tests

Extended to check the balance for `sender_id`, when `sender_id == receiver_id` in `ft_transfer_call`.
