### PR TITLE
Fix: allow deposit to be called by any account

### DIFF
--- a/eth-connector/src/lib.rs
+++ b/eth-connector/src/lib.rs
@@ -497,7 +497,6 @@ impl ConnectorWithdraw for EthConnectorContract {
 #[near_bindgen]
 impl ConnectorDeposit for EthConnectorContract {
     fn deposit(&mut self, #[serializer(borsh)] raw_proof: Proof) -> Promise {
-        self.assert_access_right().sdk_unwrap();
         self.connector.deposit(raw_proof)
     }
 }


### PR DESCRIPTION
Now that we [no longer have any notion of deposit relayer or fee](https://github.com/aurora-is-near/aurora-eth-connector/pull/16) the `deposit` function does not make use of `predecessor_id` (except to check if the caller is the owner in the pausing logic). Therefore I think it is safe to open up this function to any account, not just the Aurora Engine. I think it also important that we do this so that the `deposit` function in Aurora Engine can be deprecated and eventually removed when it is no longer used (e.g. by the bridge).