### PR TITLE
Feat: allow withdraw by users directly

### DIFF
--- a/eth-connector-tests/src/connector.rs
+++ b/eth-connector-tests/src/connector.rs
@@ -98,7 +98,7 @@ async fn test_withdraw_eth_from_near() -> anyhow::Result<()> {
     let res = contract
         .contract
         .call("withdraw")
-        .args_borsh((contract.contract.id(), recipient_addr, withdraw_amount))
+        .args_borsh((recipient_addr, withdraw_amount))
         .gas(DEFAULT_GAS)
         .deposit(ONE_YOCTO)
         .transact()
@@ -130,10 +130,57 @@ async fn test_withdraw_eth_from_near_user() -> anyhow::Result<()> {
 
     let withdraw_amount = 100;
     let recipient_addr = validate_eth_address(RECIPIENT_ETH_ADDRESS);
-    contract.set_and_check_access_right(user_acc.id()).await?;
 
     let res = user_acc
         .call(contract.contract.id(), "withdraw")
+        .args_borsh((recipient_addr, withdraw_amount))
+        .gas(DEFAULT_GAS)
+        .deposit(ONE_YOCTO)
+        .transact()
+        .await?;
+    assert!(res.is_success());
+
+    let data: WithdrawResult = res.borsh()?;
+    let custodian_addr = validate_eth_address(CUSTODIAN_ADDRESS);
+    assert_eq!(data.recipient_id, recipient_addr);
+    assert_eq!(data.amount, withdraw_amount);
+    assert_eq!(data.eth_custodian_address, custodian_addr);
+    assert_eq!(
+        contract.get_eth_on_near_balance(user_acc.id()).await?.0,
+        DEPOSITED_AMOUNT - withdraw_amount
+    );
+    assert_eq!(
+        contract.total_supply().await?.0,
+        DEPOSITED_AMOUNT - withdraw_amount
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_withdraw_eth_from_near_engine() -> anyhow::Result<()> {
+    let contract = TestContract::new().await?;
+    contract.call_deposit_eth_to_near().await?;
+    let user_acc = contract.create_sub_account("eth_recipient").await?;
+
+    let withdraw_amount = 100;
+    let recipient_addr = validate_eth_address(RECIPIENT_ETH_ADDRESS);
+
+    // Only approved accounts can call this function
+    let res = user_acc
+        .call(contract.contract.id(), "engine_withdraw")
+        .args_borsh((user_acc.id(), recipient_addr, withdraw_amount))
+        .gas(DEFAULT_GAS)
+        .deposit(ONE_YOCTO)
+        .transact()
+        .await?;
+    assert!(res.is_failure());
+    assert!(contract.check_error_message(res, "ERR_ACCESS_RIGHT"));
+
+    // The purpose of this withdraw variant is that it can withdraw on behalf of a user.
+    // In this example the contract itself withdraws on behalf of the user
+    let res = contract
+        .contract
+        .call("engine_withdraw")
         .args_borsh((user_acc.id(), recipient_addr, withdraw_amount))
         .gas(DEFAULT_GAS)
         .deposit(ONE_YOCTO)
@@ -799,7 +846,7 @@ async fn test_withdraw_from_near_pausability() -> anyhow::Result<()> {
     // 1st withdraw - should succeed
     let res = user_acc
         .call(contract.contract.id(), "withdraw")
-        .args_borsh((contract.contract.id(), recipient_addr, withdraw_amount))
+        .args_borsh((recipient_addr, withdraw_amount))
         .gas(DEFAULT_GAS)
         .deposit(ONE_YOCTO)
         .transact()
@@ -825,7 +872,7 @@ async fn test_withdraw_from_near_pausability() -> anyhow::Result<()> {
     // 2nd withdraw - should fail
     let res = user_acc
         .call(contract.contract.id(), "withdraw")
-        .args_borsh((contract.contract.id(), recipient_addr, withdraw_amount))
+        .args_borsh((recipient_addr, withdraw_amount))
         .gas(DEFAULT_GAS)
         .deposit(ONE_YOCTO)
         .transact()
@@ -845,7 +892,7 @@ async fn test_withdraw_from_near_pausability() -> anyhow::Result<()> {
 
     let res = user_acc
         .call(contract.contract.id(), "withdraw")
-        .args_borsh((contract.contract.id(), recipient_addr, withdraw_amount))
+        .args_borsh((recipient_addr, withdraw_amount))
         .gas(DEFAULT_GAS)
         .deposit(ONE_YOCTO)
         .transact()

--- a/eth-connector/src/connector.rs
+++ b/eth-connector/src/connector.rs
@@ -18,7 +18,6 @@ pub trait ConnectorWithdraw {
     #[result_serializer(borsh)]
     fn withdraw(
         &mut self,
-        #[serializer(borsh)] sender_id: AccountId,
         #[serializer(borsh)] recipient_address: Address,
         #[serializer(borsh)] amount: Balance,
     ) -> WithdrawResult;
@@ -44,6 +43,18 @@ pub trait ProofVerifier {
 #[ext_contract(ext_ft_statistic)]
 pub trait FungibleTokeStatistic {
     fn get_accounts_counter(&self) -> U64;
+}
+
+/// Withdraw method for legacy implementation in Engine
+#[ext_contract(ext_engine_withdraw)]
+pub trait EngineConnectorWithdraw {
+    #[result_serializer(borsh)]
+    fn engine_withdraw(
+        &mut self,
+        #[serializer(borsh)] sender_id: AccountId,
+        #[serializer(borsh)] recipient_address: Address,
+        #[serializer(borsh)] amount: Balance,
+    ) -> WithdrawResult;
 }
 
 /// Engin compatible methods for NEP-141


### PR DESCRIPTION
## Description

In the spirit of being able to eventually remove all connector functionality from the Engine contract, we need a method to be able to Withdraw tokens that can be called by users directly. This PR renames the `withdraw` function to `engine_withdraw` as it can only be called by Engine instances, and adds a new `withdraw` function where the sender is not passed as an argument, but instead is determined from the `predecessor_account_id`. Since the sender is no longer specified by the user the `withdraw` function no longer needs to be protected; it can be called by any user.

Note https://github.com/aurora-is-near/aurora-engine/pull/607 will need to be updated to call `engine_withdraw` instead of just `withdraw`.

## Testing

New test for the `engine_withdraw` function. Existing tests for the permissionless `withdraw` function.