### PR TITLE
Fix `verify_log_entry` call 

### DIFF
--- a/eth-connector/src/connector.rs
+++ b/eth-connector/src/connector.rs
@@ -1,11 +1,9 @@
-use crate::{connector_impl::FinishDepositCallArgs, Proof, WithdrawResult};
+use crate::{connector_impl::FinishDepositCallArgs, Proof, VerifyProofArgs, WithdrawResult};
 use aurora_engine_types::types::Address;
 use near_contract_standards::storage_management::StorageBalance;
 use near_sdk::json_types::U64;
 use near_sdk::{
-    borsh, ext_contract,
-    json_types::{Base64VecU8, U128},
-    AccountId, Balance, Promise, PromiseOrValue,
+    borsh, ext_contract, json_types::U128, AccountId, Balance, Promise, PromiseOrValue,
 };
 
 #[ext_contract(ext_deposit)]
@@ -37,7 +35,7 @@ pub trait FundsFinish {
 #[ext_contract(ext_proof_verifier)]
 pub trait ProofVerifier {
     #[result_serializer(borsh)]
-    fn verify_log_entry(&self, #[serializer(borsh)] raw_proof: Base64VecU8) -> bool;
+    fn verify_log_entry(&self, #[serializer(borsh)] args: VerifyProofArgs) -> bool;
 }
 
 #[ext_contract(ext_ft_statistic)]

--- a/eth-connector/src/proof.rs
+++ b/eth-connector/src/proof.rs
@@ -34,6 +34,31 @@ impl Proof {
     }
 }
 
+#[derive(BorshDeserialize, BorshSerialize)]
+pub struct VerifyProofArgs {
+    pub log_index: u64,
+    pub log_entry_data: Vec<u8>,
+    pub receipt_index: u64,
+    pub receipt_data: Vec<u8>,
+    pub header_data: Vec<u8>,
+    pub proof: Vec<Vec<u8>>,
+    pub skip_bridge_call: bool,
+}
+
+impl From<Proof> for VerifyProofArgs {
+    fn from(value: Proof) -> Self {
+        Self {
+            log_index: value.log_index,
+            log_entry_data: value.log_entry_data,
+            receipt_index: value.receipt_index,
+            receipt_data: value.receipt_data,
+            header_data: value.header_data,
+            proof: value.proof,
+            skip_bridge_call: false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Proof;


### PR DESCRIPTION
## Description

- Improve code readability.
- Fix arguments type for the cross call `verify_log_entry`. The tests didn't fail because the mocked `pub fn verify_log_entry` didn't accept any arguments, so the tests failed with error `ExecutionError("Smart contract panicked: Callback computation 0 was not successful")` on adding correct [arguments](https://github.com/aurora-is-near/rainbow-bridge/blob/a5f3c9148901d4c0c975bcc56a16653bc68cc035/contracts/near/eth-prover/src/lib.rs#L100)  to it.