### PR TITLE
Explicit encoding of FtTransferMessageData

### DIFF
--- a/eth-connector/src/deposit_event.rs
+++ b/eth-connector/src/deposit_event.rs
@@ -3,7 +3,6 @@ use aurora_engine_types::{
     types::{address::error::AddressError, Address, Fee, NEP141Wei},
     U256,
 };
-use byte_slice_cast::AsByteSlice;
 use ethabi::{Event, EventParam, Hash, Log, ParamType, RawLog};
 use near_sdk::{
     borsh::{self, BorshDeserialize, BorshSerialize},
@@ -80,9 +79,10 @@ impl FtTransferMessageData {
         // The first data section should contain fee data.
         // Pay attention, that for compatibility reasons we used U256 type
         // it means 32 bytes for fee data
-        let mut data = U256::from(self.fee.as_u128()).as_byte_slice().to_vec();
+        let mut data = [0; 52];
+        U256::from(self.fee.as_u128()).to_little_endian(&mut data[..32]);
         // Second data section should contain Eth address
-        data.extend(self.recipient.as_bytes());
+        data[32..].copy_from_slice(self.recipient.as_bytes());
         // Add `:` separator between relayer_id and data message
         [self.relayer.as_ref(), &hex::encode(data)].join(":")
     }


### PR DESCRIPTION
The old encoding is correct as well. Just to make encoding more explicit. 