### PR TITLE
chore: patch rust toolchain to use minimal profile

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,5 @@
 [toolchain]
 channel = "1.74.1"
-components = ["minimal", "rustfmt", "clippy"]
+components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
+profile = "minimal"


### PR DESCRIPTION
## Description
PR adjusts rust-toolchain to use minimal profile, this is done to pass security analysis workflows

## Performance / NEAR gas cost considerations
N/A

## Testing
N/A

## How should this be reviewed
Schedule security analysis workflow to check CI behavior.

## Additional information
Shared security workflows run static analysis tools, in this case clippy.
